### PR TITLE
port forwarding, machine name, correct init.d start

### DIFF
--- a/db/Vagrantfile
+++ b/db/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(2) do |config|
 
   # Ubuntu 16.04, 64 bit
   config.vm.box         = "bento/ubuntu-16.04"
+  config.vm.define "rethinkdb"
 
   # Set memory to 1024
   # Allow I/O APIC
@@ -21,6 +22,7 @@ Vagrant.configure(2) do |config|
 
   # Static IP
   config.vm.network :private_network, ip: rethinkdb_host_ip
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
 
   # Provisioning
   config.vm.provision :shell do |sh|
@@ -38,7 +40,7 @@ Vagrant.configure(2) do |config|
       rethinkdb create -d /var/lib/rethinkdb/instances.d/default 2>&1;
 
       # Start rethinkdb
-      service rethinkdb start;
+      /etc/init.d/rethinkdb restart;
     EOF
   end
 end


### PR DESCRIPTION
I noticed a few things missing in the Vagrantfile. The machine was being named 'default', so I named it explicitly. The management console on port 8080 was not being forwarded, so was inaccessible from the host's IP. Finally, there was an error trying to automatically start the rethinkdb service, so I changed it to the recommended command. 